### PR TITLE
Add a link to the crates.io security page in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,7 +1,13 @@
 The [Rust Security Response WG][team] handles vulnerability reports and
 security issues for all the repositories in the **rust-lang** and
 **rust-lang-nursery** organizations. If you found a vulnerability please report
-it [according to the security policy on our website][policy]. Thanks!
+it [according to the security policy on our website][policy]. 
+
+For security issues with crates written in Rust, see [the crates.io security 
+page][crates].
+
+Thanks!
 
 [team]: https://www.rust-lang.org/governance/wgs/wg-security-response
 [policy]: https://www.rust-lang.org/policies/security
+[crates]: https://crates.io/policies/security


### PR DESCRIPTION
Crates.io now has its own security page that has information relevant to the broader Rust ecosystem. People may look for this information in rust-lang's SECURITY.md. I think it makes sense to have that information linked here just in case.

Pietro is working on linking to https://crates.io/policies/security from https://www.rust-lang.org/policies/security, the latter of which is already linked here, but that's 2 clicks away.

I am open to wording changes to make this clearer; I am also open to this being rejected as not relevant in this location or not needed because the Rust security page will soon link to the crates.io security page.

But I'm on a mission to spread info that the Foundation can help crate authors with security problems by getting the information out as much as possible, so I figured I'd try adding it here and see what folks think.