### PR TITLE
Update security team link in SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,5 +3,5 @@ security issues for all the repositories in the **rust-lang** and
 **rust-lang-nursery** organizations. If you found a vulnerability please report
 it [according to the security policy on our website][policy]. Thanks!
 
-[team]: https://www.rust-lang.org/governance/wgs/wg-security-response
+[team]: https://rust-lang.org/governance/teams/launching-pad/#team-security-response
 [policy]: https://www.rust-lang.org/policies/security


### PR DESCRIPTION
https://www.rust-lang.org/governance/wgs/wg-security-response is currently invalid

it's moved to https://rust-lang.org/governance/teams/launching-pad/#team-security-response

@pietroalbini 